### PR TITLE
Added truncateResponse flag for Breach API

### DIFF
--- a/HIBP.NET/Apis/BreachAPi.cs
+++ b/HIBP.NET/Apis/BreachAPi.cs
@@ -64,13 +64,13 @@ namespace HIBP
         /// <returns>
         /// A list of <see cref="Breach"/>
         /// </returns>
-        public async Task<IEnumerable<Breach>> GetBreachesForAccountAsync(string account, string domain = null, bool includeUnverified = false)
+        public async Task<IEnumerable<Breach>> GetBreachesForAccountAsync(string account, bool truncateResponse = false, string domain = null, bool includeUnverified = false)
         {
             if (string.IsNullOrWhiteSpace(account))
                 throw new ArgumentNullException("account");
 
             var _account = System.Web.HttpUtility.UrlEncode(account);
-            var endpoint = $"breachedaccount/{_account}/?includeUnverified={includeUnverified.ToBooleanString()}";
+            var endpoint = $"breachedaccount/{_account}/?truncateResponse={truncateResponse.ToBooleanString()}&includeUnverified={includeUnverified.ToBooleanString()}";
             if (domain != null)
                 endpoint += $"&domain={domain}";
 

--- a/HIBP.NET/Apis/IBreachApi.cs
+++ b/HIBP.NET/Apis/IBreachApi.cs
@@ -8,6 +8,6 @@ namespace HIBP
     {
         Task<Breach> GetBreachAsync(string name);
         Task<IEnumerable<Breach>> GetBreachesAsync(string domain = null, bool includeUnverified = false);
-        Task<IEnumerable<Breach>> GetBreachesForAccountAsync(string account, string domain = null, bool includeUnverified = false);
+        Task<IEnumerable<Breach>> GetBreachesForAccountAsync(string account, bool truncateResponse = false, string domain = null, bool includeUnverified = false);
     }
 }


### PR DESCRIPTION
GetBreachesForAccountAsync() was truncating responses for breaches so I added the supported truncateResponse flag. It defaults to false but can be overridden by providing the boolean to the function call.